### PR TITLE
Fix TokenRequired imports

### DIFF
--- a/backend/api/views/institution_viewset.py
+++ b/backend/api/views/institution_viewset.py
@@ -1,7 +1,8 @@
-from rest_framework import viewsets
-from api.models import Institution
+from rest_framework import viewsets, status
+from rest_framework.response import Response
+from api.models import Institution, User
 from api.serializers import InstitutionSerializer
-from api.views import TokenRequired
+from .TokenRequired import TokenRequired
 
 class InstitutionViewSet(viewsets.ModelViewSet):
     queryset = Institution.objects.all()

--- a/backend/api/views/user_viewset.py
+++ b/backend/api/views/user_viewset.py
@@ -1,8 +1,9 @@
-from rest_framework import viewsets
+from rest_framework import viewsets, status
+from rest_framework.response import Response
 from rest_framework.decorators import action
 from api.models import User
 from api.serializers import UserSerializer
-from api.views import TokenRequired
+from .TokenRequired import TokenRequired
 
 class UserViewSet(viewsets.ModelViewSet):
     queryset = User.objects.all()


### PR DESCRIPTION
## Summary
- fix import paths for `TokenRequired` in `user_viewset` and `institution_viewset`
- import Response/status and User model

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6864ca75596083228ddd849dfb74f5f1